### PR TITLE
Bug fix--switching add-ons did not clear captions.

### DIFF
--- a/HLACaptionReplacer-UI/ClosedCaptionDependencyObject.cs
+++ b/HLACaptionReplacer-UI/ClosedCaptionDependencyObject.cs
@@ -31,7 +31,14 @@ namespace HLACaptionReplacer
             ClosedCaptionDependencyObject me = d as ClosedCaptionDependencyObject;
             if (me != null)
             {
-                me.Caption.SoundEvent = me.Name;
+                if (!string.IsNullOrEmpty(me.Name))
+                {
+                    me.Caption.SoundEvent = me.Name;
+                }
+                else
+                {
+
+                }
             }
         }
 

--- a/HLACaptionReplacer-UI/MainWindow.xaml.cs
+++ b/HLACaptionReplacer-UI/MainWindow.xaml.cs
@@ -123,6 +123,7 @@ namespace HLACaptionReplacer
         void LoadCaptionData()
         {
             string addonFolder = Steam.SteamData.GetHLAAddOnFolder(AddOn);
+            Captions = new ObservableCollection<ClosedCaptionDependencyObject>();
             SoundNames = new ObservableCollection<string>();
             hashToName = new Dictionary<uint, string>();
             foreach (var eventFiles in new DirectoryInfo(addonFolder).GetFiles("*." + Steam.SteamData.SoundEventsExtension, SearchOption.AllDirectories))

--- a/HLACaptionReplacerLibrary/ClosedCaption.cs
+++ b/HLACaptionReplacerLibrary/ClosedCaption.cs
@@ -28,7 +28,11 @@ namespace HLACaptionReplacer
             set
             {
                 soundEvent = value;
-                SoundEventHash = ValveResourceFormat.Crc32.Compute(Encoding.UTF8.GetBytes(soundEvent));
+                if (!string.IsNullOrEmpty(soundEvent))
+                {
+                    SoundEventHash = ValveResourceFormat.Crc32.Compute(Encoding.UTF8.GetBytes(soundEvent));
+                }
+
             }
         }
 


### PR DESCRIPTION
Tested multiple (3) custom captions and all worked as expected.

The New GUI will create a custom caption file in game/hlvr_addons/addon/resource/subtitles with the naming convention of closecaption_<language>_custom.dat.  To use in game, the console command cc_lang <language>_custom must be executed.